### PR TITLE
Service name created should match manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ applications:
 5. Create the Personality Insights service in Bluemix
 
   ```sh
-  $ cf create-service personality_insights standard personality-insights-service
+  $ cf create-service personality_insights standard personality-insights-service-standard
   ```
 
 6. Push it live!


### PR DESCRIPTION
`manifest.js` contains `personality-insights-service-standard` but the readme was missing the `-standard` suffix.