### PR TITLE
Implement Consumption preferences for v3 PI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 .env.js
 .env
 coverage
+.idea/*

--- a/helpers/personality-insights.js
+++ b/helpers/personality-insights.js
@@ -52,6 +52,7 @@ var
             }
             response.consumption_preferences = [];
           }
+          response.raw_v3_response = cpresponse;
           callback(err, response)
         });
       });

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "request": "^2.72.0",
     "twitter": "1.3.0",
     "underscore": "^1.8.3",
-    "watson-developer-cloud": "^1.9.4",
+    "watson-developer-cloud": "^2.6.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "request": "^2.72.0",
     "twitter": "1.3.0",
     "underscore": "^1.8.3",
-    "watson-developer-cloud": "^2.6.0",
+    "watson-developer-cloud": "^2.6.1",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -515,14 +515,19 @@ $(document).ready(function () {
     "consumption_preferences_movie_documentary"]);
 
   function addIfAllowedReducer(accumulator, toadd) {
-    if (consumptionPrefMusic.has(toadd.cpid) && accumulator.reduce(function(k,v) {
-          return consumptionPrefMusic.has(v.cpid) ? k + 1 : k;
-        },0) < 1) {
-      accumulator.push(toadd);
-    } else if (consumptionPrefMovie.has(toadd.cpid) && accumulator.reduce(function(k,v) {
+    if (consumptionPrefMusic.has(toadd.cpid)) {
+      if (accumulator.reduce(function(k,v) {
+            return consumptionPrefMusic.has(v.cpid) ? k + 1 : k;
+          },0) < 1) {
+        accumulator.push(toadd);
+      }
+    } else if (consumptionPrefMovie.has(toadd.cpid)) {
+
+      if(accumulator.reduce(function(k,v) {
           return consumptionPrefMovie.has(v.cpid) ? k + 1 : k;
         },0) < 1) {
-      accumulator.push(toadd);
+        accumulator.push(toadd);
+      }
     } else {
       accumulator.push(toadd);
     }

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -401,13 +401,14 @@ $(document).ready(function () {
         });
         return k;
       },[]);
-      behaviors.append("<h4 class=\"base--h4\">You are likely to _______ </h4>");
+      behaviors.html("");
+      behaviors.append("<h4 class=\"base--h4\">You are likely to______ </h4>");
       behaviors.append("<div class=\"output-summary--likely-behaviors\">");
       likelycps.slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item + "</div>\n");
       });
       behaviors.append("</div>");
-      behaviors.append("<h4 class=\"base--h4\">You are unlikely to _______ </h4>");
+      behaviors.append("<h4 class=\"base--h4\">You are unlikely to______ </h4>");
       behaviors.append("<div class=\"output-summary--unlikely-behaviors\">");
       unlikelycps.slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_NEGATIVE\"><i class=\"icon icon-not-likely\"></i>" + item + "</div>\n");

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -380,6 +380,64 @@ $(document).ready(function () {
     });
   }
 
+  function cpIdMapping(cpid) {
+    return {
+      "consumption_preferences_automobile_ownership_cost": "be sensitive to ownership cost when buying automobiles",
+        "consumption_preferences_automobile_safety": "prefer safety when buying automobiles",
+        "consumption_preferences_automobile_resale_value": "prefer resale value when buying automobiles",
+        "consumption_preferences_clothes_quality": "prefer quality when buying clothes",
+        "consumption_preferences_clothes_style": "prefer style when buying clothes",
+        "consumption_preferences_clothes_comfort": "prefer comfort when buying clothes",
+        "consumption_preferences_influence_brand_name": "be influenced by brand name when making product purchases",
+        "consumption_preferences_influence_utility": "be influenced by product utility when making product purchases",
+        "consumption_preferences_influence_online_ads": "be influenced by online ads when making product purchases",
+        "consumption_preferences_influence_social_media": "be influenced by social media during product purchases",
+        "consumption_preferences_influence_family_members": "be influenced by family when making product purchases",
+        "consumption_preferences_spur_of_moment": "indulge in spur of the moment purchases",
+        "consumption_preferences_credit_card_payment": "prefer using credit cards for shopping",
+        "consumption_preferences_eat_out": "eat out frequently",
+        "consumption_preferences_fast_food_frequency": "eat fast food frequently",
+        "consumption_preferences_gym_membership": "have a gym membership",
+        "consumption_preferences_adventurous_sports": "like adventurous sports",
+        "consumption_preferences_outdoor": "like outdoor activities",
+        "consumption_preferences_concerned_environment": "be concerned about the environment",
+        "consumption_preferences_start_business": "consider starting a business in next few years",
+        "consumption_preferences_movie_romance": "like romance movies",
+        "consumption_preferences_movie_adventure": "like adventure movies",
+        "consumption_preferences_movie_horror": "like horror movies",
+        "consumption_preferences_movie_musical": "like musical movies",
+        "consumption_preferences_movie_historical": "like historical movies",
+        "consumption_preferences_movie_science_fiction": "like science-fiction movies",
+        "consumption_preferences_movie_war": "like war movies",
+        "consumption_preferences_movie_drama": "like drama movies",
+        "consumption_preferences_movie_action": "like action movies",
+        "consumption_preferences_movie_documentary": "like documentary movies",
+        "consumption_preferences_music_rap": "like rap music",
+        "consumption_preferences_music_country": "like country music",
+        "consumption_preferences_music_r_b": "like R&B music",
+        "consumption_preferences_music_hip_hop": "like hip hop music",
+        "consumption_preferences_music_live_event": "attend live musical events",
+        "consumption_preferences_music_christian_gospel": "like Christian/gospel music",
+        "consumption_preferences_music_playing": "have experience playing music",
+        "consumption_preferences_music_latin": "like Latin music",
+        "consumption_preferences_music_rock": "like rock music",
+        "consumption_preferences_music_classical": "like classical music",
+        "consumption_preferences_read_frequency": "read often",
+        "consumption_preferences_read_motive_enjoyment": "read for enjoyment",
+        "consumption_preferences_read_motive_information": "read for information",
+        "consumption_preferences_books_entertainment_magazines": "like entertainment magazines",
+        "consumption_preferences_books_non_fiction": "like non-fiction books",
+        "consumption_preferences_read_motive_mandatory": "do mandatory reading only",
+        "consumption_preferences_read_motive_relaxation": "read for relaxation",
+        "consumption_preferences_books_financial_investing": "read financial investment books",
+        "consumption_preferences_books_autobiographies": "read autobiographical books",
+        "consumption_preferences_volunteer": "volunteer for social causes",
+        "consumption_preferences_volunteering_time": "have spent time volunteering",
+        "consumption_preferences_volunteer_learning": "volunteer for learning",
+    }[cpid]
+
+  }
+
   function loadConsumptionPreferences(data) {
     var cpsect = $(".output-summary--consumption-behaviors--section")
     var behaviors = $(".output-summary--consumption-behaviors--section")
@@ -387,7 +445,7 @@ $(document).ready(function () {
       var likelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 1) {
-            k.push(child_item.name);
+            k.push(cpIdMapping(item.id));
           }
         });
         return k;
@@ -396,7 +454,7 @@ $(document).ready(function () {
       var unlikelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 0) {
-            k.push(child_item.name);
+            k.push(cpIdMapping(item.id));
           }
         });
         return k;

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -480,15 +480,15 @@ $(document).ready(function () {
         "consumption_preferences_read_frequency": "read often",
         "consumption_preferences_read_motive_enjoyment": "read for enjoyment",
         "consumption_preferences_read_motive_information": "read for information",
-        "consumption_preferences_books_entertainment_magazines": "like entertainment magazines",
-        "consumption_preferences_books_non_fiction": "like non-fiction books",
+        "consumption_preferences_books_entertainment_magazines": "read entertainment magazines",
+        "consumption_preferences_books_non_fiction": "read non-fiction books",
         "consumption_preferences_read_motive_mandatory": "do mandatory reading only",
         "consumption_preferences_read_motive_relaxation": "read for relaxation",
         "consumption_preferences_books_financial_investing": "read financial investment books",
         "consumption_preferences_books_autobiographies": "read autobiographical books",
         "consumption_preferences_volunteer": "volunteer for social causes",
         "consumption_preferences_volunteering_time": "have spent time volunteering",
-        "consumption_preferences_volunteer_learning": "volunteer for learning",
+        "consumption_preferences_volunteer_learning": "volunteer to learn about social causes",
     }[cpid]
 
   }

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -380,6 +380,61 @@ $(document).ready(function () {
     });
   }
 
+  function cpIdSorting(cpid) {
+    return ["consumption_preferences_music_rap",
+      "consumption_preferences_music_country",
+      "consumption_preferences_concerned_environment",
+      "consumption_preferences_read_frequency",
+      "consumption_preferences_music_r_b",
+      "consumption_preferences_volunteer_learning",
+      "consumption_preferences_automobile_ownership_cost",
+      "consumption_preferences_automobile_safety",
+      "consumption_preferences_volunteer",
+      "consumption_preferences_movie_romance",
+      "consumption_preferences_eat_out",
+      "consumption_preferences_music_hip_hop",
+      "consumption_preferences_movie_adventure",
+      "consumption_preferences_movie_horror",
+      "consumption_preferences_influence_brand_name",
+      "consumption_preferences_music_live_event",
+      "consumption_preferences_clothes_quality",
+      "consumption_preferences_automobile_resale_value",
+      "consumption_preferences_clothes_style",
+      "consumption_preferences_read_motive_enjoyment",
+      "consumption_preferences_music_christian_gospel",
+      "consumption_preferences_read_motive_information",
+      "consumption_preferences_books_entertainment_magazines",
+      "consumption_preferences_books_non_fiction",
+      "consumption_preferences_start_business",
+      "consumption_preferences_read_motive_mandatory",
+      "consumption_preferences_gym_membership",
+      "consumption_preferences_influence_family_members",
+      "consumption_preferences_adventurous_sports",
+      "consumption_preferences_movie_musical",
+      "consumption_preferences_movie_historical",
+      "consumption_preferences_movie_science_fiction",
+      "consumption_preferences_volunteering_time",
+      "consumption_preferences_spur_of_moment",
+      "consumption_preferences_movie_war",
+      "consumption_preferences_credit_card_payment",
+      "consumption_preferences_movie_drama",
+      "consumption_preferences_read_motive_relaxation",
+      "consumption_preferences_influence_utility",
+      "consumption_preferences_music_playing",
+      "consumption_preferences_books_financial_investing",
+      "consumption_preferences_fast_food_frequency",
+      "consumption_preferences_movie_action",
+      "consumption_preferences_influence_online_ads",
+      "consumption_preferences_books_autobiographies",
+      "consumption_preferences_influence_social_media",
+      "consumption_preferences_music_latin",
+      "consumption_preferences_music_rock",
+      "consumption_preferences_outdoor",
+      "consumption_preferences_music_classical",
+      "consumption_preferences_movie_documentary",
+      "consumption_preferences_clothes_comfort" ].indexOf(cpid);
+  }
+
   function cpIdMapping(cpid) {
     return {
       "consumption_preferences_automobile_ownership_cost": "be sensitive to ownership cost when buying automobiles",
@@ -445,7 +500,8 @@ $(document).ready(function () {
       var likelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 1) {
-            k.push(cpIdMapping(child_item.consumption_preference_id));
+            k.push({ name: cpIdMapping(child_item.consumption_preference_id),
+              idx: cpIdSorting(child_item.consumption_preference_id) });
           }
         });
         return k;
@@ -454,7 +510,8 @@ $(document).ready(function () {
       var unlikelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 0) {
-            k.push(cpIdMapping(child_item.consumption_preference_id));
+            k.push({ name: cpIdMapping(child_item.consumption_preference_id),
+              idx: cpIdSorting(child_item.consumption_preference_id) });
           }
         });
         return k;
@@ -462,14 +519,14 @@ $(document).ready(function () {
       behaviors.html("");
       behaviors.append("<h4 class=\"base--h4\">You are likely to______ </h4>");
       behaviors.append("<div class=\"output-summary--likely-behaviors\">");
-      likelycps.slice(0,3).map(function(item) {
-        behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item + "</div>\n");
+      likelycps.sort(function(l,r) { return l.idx > r.idx; }).slice(0,3).map(function(item) {
+        behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");
       behaviors.append("<h4 class=\"base--h4\">You are unlikely to______ </h4>");
       behaviors.append("<div class=\"output-summary--unlikely-behaviors\">");
-      unlikelycps.slice(0,3).map(function(item) {
-        behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_NEGATIVE\"><i class=\"icon icon-not-likely\"></i>" + item + "</div>\n");
+      unlikelycps.sort(function(l,r) { return l.idx > r.idx; }).slice(0,3).map(function(item) {
+        behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_NEGATIVE\"><i class=\"icon icon-not-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");
       cpsect.show();

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -445,7 +445,7 @@ $(document).ready(function () {
       var likelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 1) {
-            k.push(cpIdMapping(item.id));
+            k.push(cpIdMapping(child_item.consumption_preference_id));
           }
         });
         return k;
@@ -454,7 +454,7 @@ $(document).ready(function () {
       var unlikelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 0) {
-            k.push(cpIdMapping(item.id));
+            k.push(cpIdMapping(child_item.consumption_preference_id));
           }
         });
         return k;

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -534,6 +534,20 @@ $(document).ready(function () {
     return accumulator;
   }
 
+  function sortIdxComparator(a, b) {
+    if (a < b) {
+      return -1;
+    }
+
+    if (a > b) {
+      return 1;
+    }
+
+    if (a === b) {
+      return 0;
+    }
+  }
+
   function loadConsumptionPreferences(data) {
     var cpsect = $(".output-summary--consumption-behaviors--section")
     var behaviors = $(".output-summary--consumption-behaviors--section")
@@ -564,13 +578,13 @@ $(document).ready(function () {
       behaviors.html("");
       behaviors.append("<h4 class=\"base--h4\">You are likely to______ </h4>");
       behaviors.append("<div class=\"output-summary--likely-behaviors\">");
-      likelycps.sort(function(l,r) { return l.idx > r.idx; }).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
+      likelycps.sort(sortIdxComparator).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");
       behaviors.append("<h4 class=\"base--h4\">You are unlikely to______ </h4>");
       behaviors.append("<div class=\"output-summary--unlikely-behaviors\">");
-      unlikelycps.sort(function(l,r) { return l.idx > r.idx; }).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
+      unlikelycps.sort(sortIdxComparator).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_NEGATIVE\"><i class=\"icon icon-not-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -380,33 +380,39 @@ $(document).ready(function () {
     });
   }
 
-  function shuffleinplace(a) {
-    var j, temp;
-    for (var i = a.length; i; i--) {
-      j = Math.floor(Math.random() * i);
-      temp = a[i - 1];
-      a[i - 1] = a[j];
-      a[j] = temp;
-    }
-  }
-
   function loadConsumptionPreferences(data) {
     var cpsect = $(".output-summary--consumption-behaviors--section")
-    var behaviors = $(".output-summary--likely-behaviors")
+    var behaviors = $(".output-summary--consumption-behaviors--section")
     if (data.consumption_preferences) {
-      var allcps = data.consumption_preferences.reduce(function(k,v) {
+      var likelycps = data.consumption_preferences.reduce(function(k,v) {
         v.consumption_preferences.map(function(child_item) {
-          k.push(child_item.name);
+          if (child_item.score === 1) {
+            k.push(child_item.name);
+          }
         });
         return k;
       },[]);
-      shuffleinplace(allcps);
 
-
-      behaviors.html(allcps.slice(0,10).reduce(function(acc,item) {
-        acc = acc + "<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\">" + item + "</div>\n";
-        return acc;
-      },""));
+      var unlikelycps = data.consumption_preferences.reduce(function(k,v) {
+        v.consumption_preferences.map(function(child_item) {
+          if (child_item.score === 0) {
+            k.push(child_item.name);
+          }
+        });
+        return k;
+      },[]);
+      behaviors.append("<h4 class=\"base--h4\">You are likely to _______ </h4>");
+      behaviors.append("<div class=\"output-summary--likely-behaviors\">");
+      likelycps.slice(0,3).map(function(item) {
+        behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item + "</div>\n");
+      });
+      behaviors.append("</div>");
+      behaviors.append("<h4 class=\"base--h4\">You are unlikely to _______ </h4>");
+      behaviors.append("<div class=\"output-summary--unlikely-behaviors\">");
+      unlikelycps.slice(0,3).map(function(item) {
+        behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_NEGATIVE\"><i class=\"icon icon-not-likely\"></i>" + item + "</div>\n");
+      });
+      behaviors.append("</div>");
       cpsect.show();
     } else {
       cpsect.hide();
@@ -684,7 +690,7 @@ $(document).ready(function () {
   }
 
   function updateJSON(results) {
-    $outputJSONCode.html(JSON.stringify(results, null, 2));
+    $outputJSONCode.html(JSON.stringify(results['raw_v3_response'], null, 2));
     $('.code--json').each(function (i,b) { hljs.highlightBlock(b); });
   }
 

--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -493,6 +493,42 @@ $(document).ready(function () {
 
   }
 
+  var consumptionPrefMusic = new Set(["consumption_preferences_music_rap",
+    "consumption_preferences_music_country",
+    "consumption_preferences_music_r_b",
+    "consumption_preferences_music_hip_hop",
+    "consumption_preferences_music_live_event",
+    "consumption_preferences_music_playing",
+    "consumption_preferences_music_latin",
+    "consumption_preferences_music_rock",
+    "consumption_preferences_music_classical" ]);
+
+  var consumptionPrefMovie = new Set(["consumption_preferences_movie_romance",
+    "consumption_preferences_movie_adventure",
+    "consumption_preferences_movie_horror",
+    "consumption_preferences_movie_musical",
+    "consumption_preferences_movie_historical",
+    "consumption_preferences_movie_science_fiction",
+    "consumption_preferences_movie_war",
+    "consumption_preferences_movie_drama",
+    "consumption_preferences_movie_action",
+    "consumption_preferences_movie_documentary"]);
+
+  function addIfAllowedReducer(accumulator, toadd) {
+    if (consumptionPrefMusic.has(toadd.cpid) && accumulator.reduce(function(k,v) {
+          return consumptionPrefMusic.has(v.cpid) ? k + 1 : k;
+        },0) < 1) {
+      accumulator.push(toadd);
+    } else if (consumptionPrefMovie.has(toadd.cpid) && accumulator.reduce(function(k,v) {
+          return consumptionPrefMovie.has(v.cpid) ? k + 1 : k;
+        },0) < 1) {
+      accumulator.push(toadd);
+    } else {
+      accumulator.push(toadd);
+    }
+    return accumulator;
+  }
+
   function loadConsumptionPreferences(data) {
     var cpsect = $(".output-summary--consumption-behaviors--section")
     var behaviors = $(".output-summary--consumption-behaviors--section")
@@ -501,7 +537,9 @@ $(document).ready(function () {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 1) {
             k.push({ name: cpIdMapping(child_item.consumption_preference_id),
-              idx: cpIdSorting(child_item.consumption_preference_id) });
+              idx: cpIdSorting(child_item.consumption_preference_id),
+              cpid: child_item.consumption_preference_id
+            });
           }
         });
         return k;
@@ -511,7 +549,9 @@ $(document).ready(function () {
         v.consumption_preferences.map(function(child_item) {
           if (child_item.score === 0) {
             k.push({ name: cpIdMapping(child_item.consumption_preference_id),
-              idx: cpIdSorting(child_item.consumption_preference_id) });
+              idx: cpIdSorting(child_item.consumption_preference_id),
+              cpid: child_item.consumption_preference_id
+            });
           }
         });
         return k;
@@ -519,13 +559,13 @@ $(document).ready(function () {
       behaviors.html("");
       behaviors.append("<h4 class=\"base--h4\">You are likely to______ </h4>");
       behaviors.append("<div class=\"output-summary--likely-behaviors\">");
-      likelycps.sort(function(l,r) { return l.idx > r.idx; }).slice(0,3).map(function(item) {
+      likelycps.sort(function(l,r) { return l.idx > r.idx; }).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");
       behaviors.append("<h4 class=\"base--h4\">You are unlikely to______ </h4>");
       behaviors.append("<div class=\"output-summary--unlikely-behaviors\">");
-      unlikelycps.sort(function(l,r) { return l.idx > r.idx; }).slice(0,3).map(function(item) {
+      unlikelycps.sort(function(l,r) { return l.idx > r.idx; }).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_NEGATIVE\"><i class=\"icon icon-not-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -165,17 +165,9 @@
               <a class="base--a output-summary--summary-link" href="https://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/personality-insights/sample.shtml" target="_blank"><$= __("button-how") $></a>
             </div>
             <div class="output-summary--right">
-              <div class="output-summary--likely-behaviors--section">
-                <h4 class="base--h4"><$= __("behavior-likely") $>______</h4>
+              <div class="output-summary--consumption-behaviors--section">
+                <h4 class="base--h4">Some Consumption Preferences are:</h4>
                 <div class="output-summary--likely-behaviors"></div>
-              </div>
-              <div class="output-summary--unlikely-behaviors--section">
-                <h4 class="base--h4"><$= __("behavior-unlikely") $>______</h4>
-                <div class="output-summary--unlikely-behaviors"></div>
-              </div>
-              <div class="output-summary--no-behaviors--section">
-                <h4 class="base--h4"><$= __("behavior-nomatch") $></h4>
-                <p class="base--p"><$= __("behavior-nomatch-1") $></p>
               </div>
             </div>
           </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -168,6 +168,7 @@
               <div class="output-summary--consumption-behaviors--section">
                 <h4 class="base--h4">Some Consumption Preferences are:</h4>
                 <div class="output-summary--likely-behaviors"></div>
+                <a class="base-a" target=“_blank” href=“http://www.ibm.com/watson/developercloud/doc/personality-insights/”> More about Consumption Preferences</a>
               </div>
             </div>
           </div>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -166,9 +166,6 @@
             </div>
             <div class="output-summary--right">
               <div class="output-summary--consumption-behaviors--section">
-                <h4 class="base--h4">Some Consumption Preferences are:</h4>
-                <div class="output-summary--likely-behaviors"></div>
-                <a class="base-a" target=“_blank” href=“http://www.ibm.com/watson/developercloud/doc/personality-insights/”> More about Consumption Preferences</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Limit to a max of one music and one movie in responses.
Fixes Watson/developer-experience#977
Limit of one music and one movie per results for consumption preferences.

also reorder consumption prefs based on list in #412

Neil listed the approved mapping in #974.

changes to display only 3 and sort into likely/unlikley