### PR TITLE
Fixes missing css class for messages

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -149,7 +149,7 @@
             <div class="output--word-count-message output--word-count-message_STRONG_NEW_MODEL"><$= __("analysis-strong") $>
               <div class="output--word-count-tooltip_STRONG tooltip"><$= __("analysis-strong-desc-new-model") $></div>
             </div>
-            <div class="output--word-count-message output--word-count-message_DECENT"><$= __("analysis-decent") $>
+            <div class="output--word-count-message output--word-count-message_DECENT_NEW_MODEL"><$= __("analysis-decent") $>
               <div class="output--word-count-tooltip_DECENT_NEW_MODEL tooltip"><$= __("analysis-decent-desc-new-model") $></div>
             </div>
             <div class="output--word-count-message output--word-count-message_WEAK_NEW_MODEL"><$= __("analysis-weak") $>


### PR DESCRIPTION
As reported in #117 the analysis messages were missing
a class on the new model divs, which made the display unclear (it looked
like it was a duplicate message).

Fixes #117