### PR TITLE
Fixed bug for consumption order preference order - the preferences be…

### DIFF
--- a/public/js/demo.js
+++ b/public/js/demo.js
@@ -692,7 +692,11 @@ $(document).ready(function () {
     return accumulator;
   }
 
-  function sortIdxComparator(a, b) {
+  function sortIdxComparator(x, y) {
+
+    var a = x.idx;
+    var b = y.idx;
+
     if (a < b) {
       return -1;
     }
@@ -736,7 +740,10 @@ $(document).ready(function () {
       behaviors.html("");
       behaviors.append("<h4 class=\"base--h4\">" + getLikelyToLabel() + "</h4>");
       behaviors.append("<div class=\"output-summary--likely-behaviors\">");
-      likelycps.sort(sortIdxComparator).reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
+
+      
+      var likelycps_sorted = likelycps.sort(sortIdxComparator);
+      likelycps_sorted.reduce(addIfAllowedReducer,[]).slice(0,3).map(function(item) {
         behaviors.append("<div class=\"output-summary--behavior output-summary--behavior_POSITIVE\"><i class=\"icon icon-likely\"></i>" + item.name + "</div>\n");
       });
       behaviors.append("</div>");


### PR DESCRIPTION
…ing shown in Chrome were different than in Firefox

This was because the sort function was being invoked on objects. However, it assumed that idx field was being passed. 