### PR TITLE
removing unpkg.com references in favor of local assets

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -40,6 +40,8 @@ module.exports = (app) => {
   app.use(bodyParser.urlencoded({extended: true, limit: '15mb'}));
   app.use(bodyParser.json({limit: '15mb'}));
   app.use(express.static(__dirname + '/../public'));
+  // make things in node_modules available (basically a replacement for unpkg.com)
+  app.use('/vendor', express.static(__dirname + '/../node_modules'));
 
   require('./i18n')(app);
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,10 @@
     "object.pick": "^1.2.0",
     "passport": "^0.3.2",
     "passport-twitter": "^1.0.4",
+    "personality-consumption-preferences": "0.0.2",
+    "personality-text-summary": "^2.1.1",
+    "personality-trait-descriptions": "^2.0.4",
+    "personality-trait-info": "^3.0.0",
     "twitter": "^1.7.0",
     "watson-developer-cloud": "^2.16.0"
   },

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -351,11 +351,11 @@
   <script type="text/javascript" src="js/components/q_util.js"></script>
   <script type="text/javascript" src="js/components/tab-panels.js"></script>
 
-  <script type="text/javascript" src="https://unpkg.com/personality-text-summary@2.1.1/dist/index.js"></script>
-  <script type="text/javascript" src="https://unpkg.com/personality-trait-info@3.0.0/dist/index.js"></script>
-  <script type="text/javascript" src="https://unpkg.com/personality-trait-descriptions@2.0.4/dist/index.js"></script>
-  <script type="text/javascript" src="https://unpkg.com/personality-trait-names@2.0.4/dist/index.js"></script>
-  <script type="text/javascript" src="https://unpkg.com/personality-consumption-preferences@0.0.2/dist/index.js"></script>
+  <script type="text/javascript" src="vendor/personality-text-summary/dist/index.js"></script>
+  <script type="text/javascript" src="vendor/personality-trait-info/dist/index.js"></script>
+  <script type="text/javascript" src="vendor/personality-trait-descriptions/dist/index.js"></script>
+  <script type="text/javascript" src="vendor/personality-trait-names/dist/index.js"></script>
+  <script type="text/javascript" src="vendor/personality-consumption-preferences/dist/index.js"></script>
   <script type="text/javascript" src="js/sunburst.js"></script>
 
   <script type="text/javascript" src="js/demo.js"></script>


### PR DESCRIPTION
This is kind of dumb (exposes *everything* under `node_modules/`), but it gets the job done quickly.  I'm pretty sure there's nothing sensitive in there;  it's all already exposed via npm and unpkg.

We should probably switch to a proper bundler eventually.