### PR TITLE
Reduce memory in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: personality-insights-livedemo
   command: npm start
   path: .
-  memory: 512M
+  memory: 256M
   instances: 1
   services:
   - my-pi-service


### PR DESCRIPTION
Reduce memory to 256MB in order to fit within the
free tier allowance.